### PR TITLE
[hasMatchingCredentials] logging and handling updated now that the matching user identifiers are returned in the url query params.

### DIFF
--- a/app/coreAPI.server.ts
+++ b/app/coreAPI.server.ts
@@ -153,8 +153,15 @@ export const hasMatchingCredentials = async (
       return null;
     }
 
-    logger.info(`Has matching credentials? ${result.match}.`);
+    logger.info(
+      `Has matching credentials? ${result.match}. ${
+        result.match
+          ? `Response wallet URL with for redirect: ${result.url}`
+          : ``
+      }`
+    );
 
+    // if there is a match then a url with the matching email and/or phone and a requestId query parameters will be returned
     return result.match ? result.url : null;
   } catch (e) {
     logger.error(`hasMatchingCredentials for ${email} failed. Error: ${e}`);

--- a/app/routes/register.tsx
+++ b/app/routes/register.tsx
@@ -46,23 +46,16 @@ export const action: ActionFunction = async ({ request }) => {
     // Check whether the user has existing credentials
     const credentialRequestUrl = await hasMatchingCredentials(email, phone);
 
+    // if url is returned then there are matching credentials
     if (credentialRequestUrl) {
-      const url = new URL(
-        String(credentialRequestUrl).toLowerCase().includes('wallet')
-          ? credentialRequestUrl
-          : config.unumWalletUrl + credentialRequestUrl
-      );
-      logger.info(`URL: ${url}`);
-      // user's email address
-      if (email) url.searchParams.set('email', email);
-      // user's phone number
-      if (phone)
-        url.searchParams.set(
-          'phone',
-          phone?.startsWith('+1') ? phone : '+1' + phone
-        );
+      const url = new URL(String(credentialRequestUrl));
+
       // url to redirect the user to once the Unum ID credential request flow is complete
       url.searchParams.set('redirectUrl', config.demoUrl + '/register');
+
+      logger.info(
+        `final wallet URL including own callbackUrl aka redirectUrl defined: ${url}`
+      );
 
       // redirect the user to the url returned from the POST request to hasMatchingCredentials
       return redirect(String(url));


### PR DESCRIPTION
[Ticket](https://trello.com/c/Qa7BNjn2/5104-update-hooli-and-kredita-demos-interfacing-with-hasmatchingcredentials-to-not-added-uids-to-query-params-just-use-the-response-u)

## Summary
`/hasMatchingCredentials` new `url` response contains the matching uids so no need to tac on here anymore.

## Changes
- dropping uid query param adding
- dropping unneeded url handling logic / conditional

## Testing
<!---
How did you test your changes? How might someone else test them?
--->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [ ] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects